### PR TITLE
Add read access for Services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -483,6 +483,7 @@ slapd_ldap_access_control_list_default:
     to *
     by {{ slapd_acl_tls_ssf }} self read
     by {{ slapd_acl_tls_ssf }} dn.subtree="ou=Machines,{{ slapd_basedn }}" read
+    by {{ slapd_acl_tls_ssf }} dn.subtree="ou=Services,{{ slapd_basedn }}" read
     by {{ slapd_acl_tls_ssf }} dn="{{ slapd_basedn_admin }}" write
     by * none
 


### PR DESCRIPTION
Most of the services created by other roles need the ability to search in the tree.
